### PR TITLE
Removed trailing &&s in venv.sls, init.sls

### DIFF
--- a/src/f0cal/bootstrap/saltbox/srv/salt/f0cal/bootstrap/dev/venv.sls
+++ b/src/f0cal/bootstrap/saltbox/srv/salt/f0cal/bootstrap/dev/venv.sls
@@ -16,7 +16,7 @@ venv_bin:
     - mode: 777
     - contents: |
         #! /bin/bash
-        {{ python_exe}} -m venv $@ && \
+        {{ python_exe}} -m venv $@
 {{ venv_dir }}:
   virtualenv.managed:
     - venv_bin: {{ temp_dir }}/.pyvenv

--- a/src/f0cal/bootstrap/saltbox/srv/salt/f0cal/bootstrap/user/init.sls
+++ b/src/f0cal/bootstrap/saltbox/srv/salt/f0cal/bootstrap/user/init.sls
@@ -17,7 +17,7 @@ venv_bin:
     - mode: 777
     - contents: |
         #! /bin/bash
-        {{ python_exe}} -m venv $@ && \
+        {{ python_exe}} -m venv $@
 {{ venv_dir }}:
   virtualenv.managed:
     - venv_bin: {{ temp_dir }}/.pyvenv


### PR DESCRIPTION
@AndreyShprengel Fix we discussed, removing the trailing '&& \' from two lines. These prevented proper creation of the venv.