### PR TITLE
Added verification of prereq apt packages.

### DIFF
--- a/src/f0cal/bootstrap/__main__.py
+++ b/src/f0cal/bootstrap/__main__.py
@@ -193,6 +193,12 @@ def main():
         6,
     ), "Sorry, this script relies on v3.6+ language features."
 
+    try:
+        print(f"Verifying required apt packages are present:")
+        subprocess.check_call(shlex.split(f"dpkg-query -W gcc python3 git python3-dev python3-venv rsync"))
+    except (ModuleNotFoundError, subprocess.CalledProcessError) as e:
+        sys.exit("One or more required apt packages not found.")
+
     parser = argparse.ArgumentParser()
 
     _descr = """These options control what is installed and where."""

--- a/src/f0cal/bootstrap/__main__.py
+++ b/src/f0cal/bootstrap/__main__.py
@@ -194,9 +194,23 @@ def main():
     ), "Sorry, this script relies on v3.6+ language features."
 
     if subprocess.getstatusoutput('dpkg-query -W')[0] == 0:
+
+        print(f"\nVerifying a compatible c compiler is present:")
+        compilers = {'gcc', 'clang'}
+        found_compiler = False
+        for compiler in compilers:
+            try:
+                subprocess.check_call(shlex.split(f"dpkg-query -W {compiler}"))
+                found_compiler = True
+                break
+            except subprocess.CalledProcessError:
+                continue
+        if not found_compiler:
+            sys.exit(f"ERROR: Did not find compatible c compiler among {str(compilers)}.")
+
         try:
-            print(f"Verifying required apt packages are present:")
-            subprocess.check_call(shlex.split(f"dpkg-query -W gcc python3 git python3-dev python3-venv rsync"))
+            print(f"\nVerifying other required apt packages are present:")
+            subprocess.check_call(shlex.split(f"dpkg-query -W python3 git python3-dev python3-venv rsync"))
         except (ModuleNotFoundError, subprocess.CalledProcessError) as e:
             sys.exit("ERROR: One or more required apt packages not found.")
 

--- a/src/f0cal/bootstrap/__main__.py
+++ b/src/f0cal/bootstrap/__main__.py
@@ -193,11 +193,12 @@ def main():
         6,
     ), "Sorry, this script relies on v3.6+ language features."
 
-    try:
-        print(f"Verifying required apt packages are present:")
-        subprocess.check_call(shlex.split(f"dpkg-query -W gcc python3 git python3-dev python3-venv rsync"))
-    except (ModuleNotFoundError, subprocess.CalledProcessError) as e:
-        sys.exit("ERROR: One or more required apt packages not found.")
+    if subprocess.getstatusoutput('dpkg-query -W')[0] == 0:
+        try:
+            print(f"Verifying required apt packages are present:")
+            subprocess.check_call(shlex.split(f"dpkg-query -W gcc python3 git python3-dev python3-venv rsync"))
+        except (ModuleNotFoundError, subprocess.CalledProcessError) as e:
+            sys.exit("ERROR: One or more required apt packages not found.")
 
     parser = argparse.ArgumentParser()
 

--- a/src/f0cal/bootstrap/__main__.py
+++ b/src/f0cal/bootstrap/__main__.py
@@ -197,7 +197,7 @@ def main():
         print(f"Verifying required apt packages are present:")
         subprocess.check_call(shlex.split(f"dpkg-query -W gcc python3 git python3-dev python3-venv rsync"))
     except (ModuleNotFoundError, subprocess.CalledProcessError) as e:
-        sys.exit("One or more required apt packages not found.")
+        sys.exit("ERROR: One or more required apt packages not found.")
 
     parser = argparse.ArgumentParser()
 


### PR DESCRIPTION
@AndreyShprengel Added verification of prerequisite apt packages `gcc python3 git python3-dev python3-venv rsync`. Without this change, if a package is missing, the installation continues and fails part way with an error that may not be obvious.

example output:
Verifying required apt packages are present:
gcc	4:7.4.0-1ubuntu2.3
git	1:2.17.1-1ubuntu0.5
python3	3.6.7-1~18.04
python3-dev	3.6.7-1~18.04
python3-venv	3.6.7-1~18.04
dpkg-query: no packages found matching rsync
ERROR: One or more required apt packages not found.