### PR TITLE
Added error message and exit if active venv or virtualenv.

### DIFF
--- a/src/f0cal/bootstrap/__main__.py
+++ b/src/f0cal/bootstrap/__main__.py
@@ -193,6 +193,13 @@ def main():
         6,
     ), "Sorry, this script relies on v3.6+ language features."
 
+    in_virtualenv = hasattr(sys, 'real_prefix')
+    in_venv = hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix
+    if in_virtualenv or in_venv:
+        print('ERROR: Found active virtualenv or venv. Deactivate before bootstrap, '
+              'since bootstrap creates its own venv.')
+        exit(1)
+
     parser = argparse.ArgumentParser()
 
     _descr = """These options control what is installed and where."""


### PR DESCRIPTION
@AndreyShprengel Added error message and exit if there is an active venv or virtualenv. Without this check, if there was an active virtualenv or venv, installation would continue and then fail in non-obvious ways.