### PR TITLE
log-level options to lowercase.

### DIFF
--- a/src/f0cal/bootstrap/__main__.py
+++ b/src/f0cal/bootstrap/__main__.py
@@ -223,7 +223,7 @@ def main():
         default=None,
         help="The temporary directory that this script uses for self-setup.",
     )
-    dev_group.add_argument("--log-level", default=None, choices=["DEBUG", "TRACE"])
+    dev_group.add_argument("--log-level", default=None, choices=["debug", "trace"])
     dev_group.add_argument(
         "--no-clean-up",
         dest="clean_up",


### PR DESCRIPTION
@AndreyShprengel Changed log-level options to lowercase. `salt-run` errored out when set `--log-level DEBUG`.

`salt-run: error: option --log-level: invalid choice: 'DEBUG' (choose from 'all', 'debug', 'error', 'critical', 'garbage', 'info', 'profile', 'quiet', 'trace', 'warning')`

In case we're purposely limiting the log options, I kept it limited to these two options.